### PR TITLE
Add "google/appengine-php-sdk" as a development dependancy for php-gds.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
     "php": ">=5.4.0",
     "google/apiclient": "1.1.3"
   },
+  "require-dev": {
+    "google/appengine-php-sdk": ">=1.9.22"
+  },
   "autoload": {
     "classmap": [
       "src/"


### PR DESCRIPTION
To assist with writing native datastore driver.