### PR TITLE
Fix phpunit to run against the appengine-php-sdk 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,13 @@ php:
   - 5.5
   - 5.6
 
-before_install:
-  - wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.21.zip
-  - unzip -q google_appengine_1.9.21.zip -d ~/
-
 before_script:
   - composer self-update
   - composer install --prefer-source
 
 script:
   - mkdir -p build/logs
-  - SDK_HOME=~/google_appengine/php/sdk
-  - php vendor/bin/phpunit -d include_path=$SDK_HOME
+  - php vendor/bin/phpunit
 
 after_script:
   - php vendor/bin/coveralls -v

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,6 +4,9 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
+    <php>
+      <includePath>vendor/google/appengine-php-sdk</includePath>
+    </php>
     <logging>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>


### PR DESCRIPTION
Fix phpunit to run against the appengine-php-sdk installed via composer rather then downloading and installing the SDK locally.

Remove the steps in travis to download the PHP SDK manually.
