### PR TITLE
Fix local GQL parser allowing invalid syntax

### DIFF
--- a/src/GDS/Gateway/ProtoBuf.php
+++ b/src/GDS/Gateway/ProtoBuf.php
@@ -333,7 +333,7 @@ class ProtoBuf extends \GDS\Gateway
 
         // Parse the GQL string
         $obj_gql_query = $obj_gql_request->getGqlQuery();
-        $obj_parser = new ProtoBufGQLParser();
+        $obj_parser = new ProtoBufGQLParser($this->obj_schema);
         $obj_parser->parse($obj_gql_query->getQueryString(), $obj_gql_query->getNameArgList());
 
         // Start applying to the new RunQuery request

--- a/src/GDS/Mapper/ProtoBufGQLParser.php
+++ b/src/GDS/Mapper/ProtoBufGQLParser.php
@@ -332,7 +332,9 @@ class ProtoBufGQLParser
                     // Check left hand side's type
                     $obj_properties = $this->obj_schema->getProperties();
                     if(!isset($obj_properties[$arr_matches['lhs']])){
-                        throw new GQL("Property doesn't exist: [{$arr_matches['lhs']}]");
+                        // We can never be sure if the property exists by the schema
+                        // Because Google Cloud Datastore is schemaless
+                        //throw new GQL("Property doesn't exist: [{$arr_matches['lhs']}]");
                     } else {
                         $int_current_type = $obj_properties[$arr_matches['lhs']]['type'];
                         switch($int_current_type) {

--- a/tests/GQLParserTest.php
+++ b/tests/GQLParserTest.php
@@ -152,6 +152,44 @@ class GQLParserTest extends \PHPUnit_Framework_TestCase
         ]], $obj_parser->getFilters());
     }
 
+    /**
+      * @expectedException              \GDS\Exception\GQL
+      * @expectedExceptionMessageRegExp /Invalid string representation in: .+/
+      */
+    public function testWhereStringQuotesMissing()
+    {
+        $obj_schema = (new GDS\Schema('Person'))
+            ->addString('some_property');
+        $obj_parser = new \GDS\Mapper\ProtoBufGQLParser($obj_schema);
+        $obj_parser->parse('SELECT * FROM Person WHERE some_property = grey');
+        $this->assertEquals('Person', $obj_parser->getKind());
+        $this->assertEquals([[
+            'lhs' => 'some_property',
+            'op' => google\appengine\datastore\v4\PropertyFilter\Operator::EQUAL,
+            'comp' => '=',
+            'rhs' => 'grey'
+        ]], $obj_parser->getFilters());
+    }
+
+    /**
+      * @expectedException              \GDS\Exception\GQL
+      * @expectedExceptionMessageRegExp /Property doesn't exist: .+/
+      */
+    public function testWhereNonexistentProperties()
+    {
+        $obj_schema = (new GDS\Schema('Person'))
+            ->addString('some_property');
+        $obj_parser = new \GDS\Mapper\ProtoBufGQLParser($obj_schema);
+        $obj_parser->parse('SELECT * FROM Person WHERE other_property = 10');
+        $this->assertEquals('Person', $obj_parser->getKind());
+        $this->assertEquals([[
+            'lhs' => 'other_property',
+            'op' => google\appengine\datastore\v4\PropertyFilter\Operator::EQUAL,
+            'comp' => '=',
+            'rhs' => 10
+        ]], $obj_parser->getFilters());
+    }
+
     public function testMultiWhere()
     {
         $obj_parser = new \GDS\Mapper\ProtoBufGQLParser();

--- a/tests/GQLParserTest.php
+++ b/tests/GQLParserTest.php
@@ -172,8 +172,9 @@ class GQLParserTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-      * @expectedException              \GDS\Exception\GQL
-      * @expectedExceptionMessageRegExp /Property doesn't exist: .+/
+      * Nonexistent properties should run fine because datastore is schemaless
+      * #expectedException              \GDS\Exception\GQL
+      * #expectedExceptionMessageRegExp /Property doesn't exist: .+/
       */
     public function testWhereNonexistentProperties()
     {


### PR DESCRIPTION
Fix on the 'WHERE' clause some invalid syntax might be allowed on the
local GQL parser. This will check if the property exists and if the
right hand side is properly represented as its type. This fixes when the
string not being properly quoted might run successfully on the local GQL
parser.