### PR TITLE
Add-on to explanation about using the JSON API

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,12 @@ Check out the [examples](examples/) folder for many more and fuller code samples
 
 A little more configuration is required if you want or need to use the JSON API instead of Protocol Buffers.
 
-The Store needs a `GDS\Gateway` to talk to Google and the gateway needs a `Google_Client` for authentication.
+The Store needs a `GDS\Gateway` to talk to Google and the gateway needs a `Google_Client` for authentication. You will need to include the [Google Client LIbrary for PHP](https://developers.google.com/api-client-library/php/) as well as create credentials for a service account in order to build the `Google_Client` properly.
+
 
 ```php
 $obj_client = GDS\Gateway\GoogleAPIClient::createGoogleClient(APP_NAME, ACCOUNT_NAME, KEY_FILE);
-$obj_gateway = new GDS\Gateway\GoogleAPIClient($obj_client, DATASET_ID);
+$obj_gateway = new GDS\Gateway\GoogleAPIClient($obj_client, PROJECT_ID);
 $obj_book_store = new GDS\Store('Book', $obj_gateway);
 ```
 
@@ -339,7 +340,7 @@ This library supports namespaces, and they are be configured per `Gateway` insta
 ```php
 // Create a store for a particular customer or 'application namespace'
 $obj_client = GDS\Gateway::createGoogleClient(APP_NAME, ACCOUNT_NAME, KEY_FILE);
-$obj_namespaced_gateway = new GDS\Gateway($obj_client, DATASET_ID, 'customer-namespace');
+$obj_namespaced_gateway = new GDS\Gateway($obj_client, PROJECT_ID, 'customer-namespace');
 $obj_namespaced_book_store = new BookStore($obj_namespaced_gateway);
 ```
 


### PR DESCRIPTION
Dataset ids don't appear to be a thing any more, and reading into the documentation its seems like these functions actually want the Google Cloud Platform project Id. This might also be part of the migration to newer API versions, since it seems like the library is currently compatible with v1beta2