### PR TITLE
Get the rest base url from the environment var so it can be used with the datastore emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Google turned down the older versions of the REST API on September 30th, 2016. V
 - [Examples](#examples)
 - [New in version 3.0](#new-in-version-20): [Datastore REST API v1 (Sep 2016)](#using-the-datastore-rest-api-v1-sep-2016)
 - [Changes in version 2.0](#changes-in-version-20)
-- [Getting Started](#getting-started) including installation with Composer
+- [Getting Started](#getting-started) including installation with Composer and setup for GDS Emulator
 - [Defining Your Model](#defining-your-model)
 - [Creating Records](#creating-records)
 - [Geopoint Support](#geopoint)
@@ -171,6 +171,9 @@ For older, version 2 series
 and for bleeding-edge features, dev-master
 
 `"tomwalder/php-gds": "dev-master"`
+
+### Use with the GDS emulator ###
+If you want to use it with the GDS emulator make sure the environment variable `DATASTORE_EMULATOR_HOST` is set with the host, for example `localhost:8081`
 
 ## Defining Your Model ##
 

--- a/src/GDS/Gateway/RESTv1.php
+++ b/src/GDS/Gateway/RESTv1.php
@@ -17,16 +17,16 @@ class RESTv1 extends \GDS\Gateway
 {
 
     /**
-     * REST API Base Endpoint
-     */
-    const BASE_URL = 'https://datastore.googleapis.com';
-
-    /**
      * Modes
      */
     const MODE_TRANSACTIONAL = 'TRANSACTIONAL';
     const MODE_NON_TRANSACTIONAL = 'NON_TRANSACTIONAL';
     const MODE_UNSPECIFIED = 'UNSPECIFIED';
+
+    /**
+     * REST API Base Endpoint
+     */
+    private $base_url = 'https://datastore.googleapis.com';
 
     /**
      * @var ClientInterface
@@ -92,10 +92,14 @@ class RESTv1 extends \GDS\Gateway
         $obj_stack = HandlerStack::create();
         $obj_stack->push(ApplicationDefaultCredentials::getMiddleware(['https://www.googleapis.com/auth/datastore']));
 
+        if (getenv("DATASTORE_EMULATOR_HOST") !== FALSE) {
+            $this->base_url = getenv("DATASTORE_EMULATOR_HOST");
+        }
+
         // Create the HTTP client
         return new Client([
             'handler' => $obj_stack,
-            'base_url' => self::BASE_URL,
+            'base_url' => $this->base_url,
             'auth' => 'google_auth'  // authorize all requests
         ]);
     }
@@ -478,7 +482,7 @@ class RESTv1 extends \GDS\Gateway
      */
     private function actionUrl($str_action)
     {
-        return self::BASE_URL . '/v1/projects/' . $this->str_dataset_id . ':' . $str_action;
+        return $this->base_url . '/v1/projects/' . $this->str_dataset_id . ':' . $str_action;
     }
 
 }


### PR DESCRIPTION
Read the datastore emulator environment variable  in the rest gateway so the api also works with the Datastore emulator.