### PR TITLE
Full Datetime support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+vendor/
 examples/scratch.php
 pb4/
 pb3/

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Google Cloud Datastore Library for PHP #
 
-Library **VERSION 3**, September 2016
+Library **VERSION 4**, October 2017
 
 [Google Cloud Datastore](https://cloud.google.com/datastore/) is a great NoSQL solution (hosted, scalable, free up to a point), but it can be tricky (i.e. there's lots of code glue needed) to get even the "Hello World" of data persistence up and running in PHP.
 
@@ -19,7 +19,9 @@ Google turned down the older versions of the REST API on September 30th, 2016. V
 ## Table of Contents ##
 
 - [Examples](#examples)
-- [New in version 3.0](#new-in-version-20): [Datastore REST API v1 (Sep 2016)](#using-the-datastore-rest-api-v1-sep-2016)
+
+- [New in version 4.0](#new-in-version-40)
+- [New in version 3.0](#new-in-version-30): [Datastore REST API v1 (Sep 2016)](#using-the-datastore-rest-api-v1-sep-2016)
 - [Changes in version 2.0](#changes-in-version-20)
 - [Getting Started](#getting-started) including installation with Composer and setup for GDS Emulator
 - [Defining Your Model](#defining-your-model)
@@ -87,6 +89,11 @@ A simple guest book application
 Application: http://php-gds-demo.appspot.com/
 
 Code: https://github.com/tomwalder/php-gds-demo
+
+## New in Version 4.0 ##
+
+* More consistent use of `DateTime` objects - now all result sets will use them instead of `'Y-m-d H:i:s'` strings   
+* Move the `google/auth` to an optional dependency
 
 ## New in Version 3.0 ##
 

--- a/README.md
+++ b/README.md
@@ -18,23 +18,22 @@ Google turned down the older versions of the REST API on September 30th, 2016. V
 
 ## Table of Contents ##
 
-- [Examples](#examples)
-
-- [New in version 4.0](#new-in-version-40)
-- [New in version 3.0](#new-in-version-30): [Datastore REST API v1 (Sep 2016)](#using-the-datastore-rest-api-v1-sep-2016)
-- [Changes in version 2.0](#changes-in-version-20)
-- [Getting Started](#getting-started) including installation with Composer and setup for GDS Emulator
-- [Defining Your Model](#defining-your-model)
-- [Creating Records](#creating-records)
-- [Geopoint Support](#geopoint)
-- [Queries, GQL & The Default Query](#queries-gql--the-default-query)
-- [Multi-tenant Applications & Data Namespaces](#multi-tenant-applications--data-namespaces)
-- [Entity Groups, Hierarchy & Ancestors](#entity-groups-hierarchy--ancestors)
-- [Transactions](#transactions)
-- [Data Migrations](#data-migrations)
-- [More About Google Cloud Datastore](#more-about-google-cloud-datastore)
-- [Unit Tests](#unit-tests)
-- [Footnotes](#footnotes)
+* [Examples](#examples)
+* [New in version 4.0](#new-in-version-40)
+* [Changes in version 3.0](#changes-in-version-30): [Datastore REST API v1 (Sep 2016)](#using-the-datastore-rest-api-v1-sep-2016)
+* [Changes in version 2.0](#changes-in-version-20)
+* [Getting Started](#getting-started) including installation with Composer and setup for GDS Emulator
+* [Defining Your Model](#defining-your-model)
+* [Creating Records](#creating-records)
+* [Geopoint Support](#geopoint)
+* [Queries, GQL & The Default Query](#queries-gql--the-default-query)
+* [Multi-tenant Applications & Data Namespaces](#multi-tenant-applications--data-namespaces)
+* [Entity Groups, Hierarchy & Ancestors](#entity-groups-hierarchy--ancestors)
+* [Transactions](#transactions)
+* [Data Migrations](#data-migrations)
+* [More About Google Cloud Datastore](#more-about-google-cloud-datastore)
+* [Unit Tests](#unit-tests)
+* [Footnotes](#footnotes)
 
 ## Examples ##
 
@@ -92,10 +91,10 @@ Code: https://github.com/tomwalder/php-gds-demo
 
 ## New in Version 4.0 ##
 
-* More consistent use of `DateTime` objects - now all result sets will use them instead of `'Y-m-d H:i:s'` strings   
-* Move the `google/auth` to an optional dependency
+* More consistent use of `DateTime` objects - now all result sets will use them instead of `Y-m-d H:i:s` strings   
+* Move the `google/auth` to an optional dependency - if you need the REST API
 
-## New in Version 3.0 ##
+## Changes in Version 3.0 ##
 
 * Support for the new **Datastore API, v1 - via REST** (gRPC to come)
 * Removal of support for the old 1.x series "PHP Google API Client"

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,16 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "google/auth": "~0.10"
+        "ext-bcmath" : "*"
     },
     "require-dev": {
+        "google/auth": "v1.0.*",
         "google/appengine-php-sdk": ">=1.9.22",
         "phpunit/phpunit": "~4.8",
         "satooshi/php-coveralls": "dev-master"
+    },
+    "suggest": {
+        "google/auth": "If you need to use the REST API (i.e. not on AppEngine Standard) Tested with v1.0.1"
     },
     "autoload": {
         "classmap": [

--- a/src/GDS/Gateway/ProtoBuf.php
+++ b/src/GDS/Gateway/ProtoBuf.php
@@ -17,6 +17,7 @@
 namespace GDS\Gateway;
 use GDS\Entity;
 use GDS\Exception\Contention;
+use GDS\Mapper;
 use GDS\Mapper\ProtoBufGQLParser;
 use google\appengine\datastore\v4\BeginTransactionRequest;
 use google\appengine\datastore\v4\BeginTransactionResponse;
@@ -413,7 +414,7 @@ class ProtoBuf extends \GDS\Gateway
             $this->createMapper()->configureGoogleKey($obj_key_value, $mix_value);
             $this->applyNamespace($obj_key_value);
         } elseif ($mix_value instanceof \DateTime) {
-            $obj_val->setTimestampMicrosecondsValue($mix_value->format('Uu'));
+            $obj_val->setTimestampMicrosecondsValue($mix_value->format(Mapper::DATETIME_FORMAT_UU));
         } elseif (method_exists($mix_value, '__toString')) {
             $obj_val->setStringValue($mix_value->__toString());
         } else {

--- a/src/GDS/Mapper.php
+++ b/src/GDS/Mapper.php
@@ -26,9 +26,15 @@ abstract class Mapper
 {
 
     /**
-     * Datetime format for backwards compatibility
+     * Datetime formats
      */
-    const DATETIME_FORMAT_V2 = 'Y-m-d H:i:s';
+    const DATETIME_FORMAT_UU = 'Uu';
+    const DATETIME_FORMAT_UDOTU = 'U.u';
+
+    /**
+     * Microseconds in a second
+     */
+    const MICROSECONDS = 1000000;
 
     /**
      * Current Schema

--- a/src/GDS/Mapper/ProtoBuf.php
+++ b/src/GDS/Mapper/ProtoBuf.php
@@ -215,7 +215,7 @@ class ProtoBuf extends \GDS\Mapper
                 } else {
                     $obj_dtm = new \DateTime($mix_value);
                 }
-                $obj_val->setTimestampMicrosecondsValue($obj_dtm->format('Uu'));
+                $obj_val->setTimestampMicrosecondsValue($obj_dtm->format(self::DATETIME_FORMAT_UU));
                 break;
 
             case Schema::PROPERTY_DOUBLE:
@@ -246,14 +246,19 @@ class ProtoBuf extends \GDS\Mapper
     /**
      * Extract a datetime value
      *
-     * @todo Validate 32bit compatibility. Consider substr() or use bc math
-     *
      * @param object $obj_property
      * @return mixed
      */
     protected function extractDatetimeValue($obj_property)
     {
-        return date(self::DATETIME_FORMAT_V2, $obj_property->getTimestampMicrosecondsValue() / 1000000);
+        // Attempt to retain microsecond precision
+        return \DateTime::createFromFormat(
+            self::DATETIME_FORMAT_UDOTU,
+            sprintf('%0.6F', bcdiv($obj_property->getTimestampMicrosecondsValue(), self::MICROSECONDS))
+        );
+
+        // Works, to seconds only
+        // return (new \DateTime())->setTimestamp($obj_property->getTimestampMicrosecondsValue() / self::MICROSECONDS);
     }
 
     /**

--- a/src/GDS/Mapper/RESTv1.php
+++ b/src/GDS/Mapper/RESTv1.php
@@ -75,8 +75,6 @@ class RESTv1 extends \GDS\Mapper
      * - past seconds in version 3.0
      * - past microseconds (down from nanoseconds) in version 4.0
      *
-     * @todo In version 4.0 we will start returning DateTime objects. Here we maintain compatibility with version 2.x
-     *
      * @param $obj_property
      * @return mixed
      */
@@ -88,7 +86,7 @@ class RESTv1 extends \GDS\Mapper
         } else {
             $obj_dtm = new \DateTime($obj_property->timestampValue);
         }
-        return $obj_dtm->format(self::DATETIME_FORMAT_V2);
+        return $obj_dtm;
     }
 
     /**

--- a/tests/ProtoBufFetchTest.php
+++ b/tests/ProtoBufFetchTest.php
@@ -257,14 +257,14 @@ class ProtoBufFetchTest extends GDSTest {
         $obj_store = new GDS\Store('Person', $obj_gateway);
         $obj_result = $obj_store->fetchById(123456789);
         $this->assertInstanceOf('\\GDS\\Entity', $obj_result);
-        $this->assertEquals($obj_result->getData(), [
+        $this->assertEquals([
             'name' => 'Tom',
             'age' => 36,
-            'dob' => '1979-02-04 08:30:00',
+            'dob' => new \DateTime('1979-02-04 08:30:00'),
             'weight' => 94.50,
             'likes_php' => TRUE,
             'home' => new \GDS\Property\Geopoint(1.23, 4.56)
-        ]);
+        ], $obj_result->getData());
         $this->apiProxyMock->verify();
     }
 
@@ -287,14 +287,14 @@ class ProtoBufFetchTest extends GDSTest {
         $obj_store = new GDS\Store($obj_schema, $obj_gateway);
         $obj_result = $obj_store->fetchById(123456789);
         $this->assertInstanceOf('\\GDS\\Entity', $obj_result);
-        $this->assertEquals($obj_result->getData(), [
+        $this->assertEquals([
             'name' => 'Tom',
             'age' => 36,
-            'dob' => '1979-02-04 08:30:00',
+            'dob' => new \DateTime('1979-02-04 08:30:00'),
             'weight' => 94.50,
             'likes_php' => TRUE,
             'home' => new \GDS\Property\Geopoint(1.23, 4.56)
-        ]);
+        ], $obj_result->getData());
         $this->apiProxyMock->verify();
     }
 

--- a/tests/RESTv1GatewayTest.php
+++ b/tests/RESTv1GatewayTest.php
@@ -429,8 +429,12 @@ class RESTv1GatewayTest extends \RESTv1Test
         $this->assertEquals($str_id, $obj_entity->getKeyId());
         $this->assertEquals('Tom', $obj_entity->name);
         $this->assertEquals(37, $obj_entity->age);
-        $this->assertEquals('2014-10-02 15:01:23', $obj_entity->dob);
-        $this->assertEquals('2012-10-02 15:01:23', $obj_entity->last_updated);
+
+        $this->assertInstanceOf(DateTime::class, $obj_entity->dob);
+        $this->assertInstanceOf(DateTime::class, $obj_entity->last_updated);
+        $this->assertEquals('2014-10-02 15:01:23', $obj_entity->dob->format('Y-m-d H:i:s'));
+        $this->assertEquals('2012-10-02 15:01:23', $obj_entity->last_updated->format('Y-m-d H:i:s'));
+
         $this->assertTrue(is_array($obj_entity->likes));
         $this->assertEquals(['Beer', 'Cycling', 'PHP'], $obj_entity->likes);
         $this->assertEquals(85.99, $obj_entity->weight);
@@ -551,7 +555,9 @@ class RESTv1GatewayTest extends \RESTv1Test
         $this->assertEquals($str_id, $obj_entity->getKeyId());
         $this->assertEquals('Tom', $obj_entity->name);
         $this->assertEquals(37, $obj_entity->age);
-        $this->assertEquals('2014-10-02 15:01:23', $obj_entity->dob);
+        $this->assertInstanceOf(DateTime::class, $obj_entity->dob);
+        $this->assertEquals('2014-10-02 15:01:23', $obj_entity->dob->format('Y-m-d H:i:s'));
+
         $this->assertTrue(is_array($obj_entity->likes));
         $this->assertEquals(['Beer', 'Cycling', 'PHP'], $obj_entity->likes);
         $this->assertEquals(85.99, $obj_entity->weight);


### PR DESCRIPTION
This version deprecates the use of datetime strings (`2001-01-01 01:01:01`) in favour of `Datetime` object usage.