### PR TITLE
Bug/support null query param value

### DIFF
--- a/src/GDS/Gateway.php
+++ b/src/GDS/Gateway.php
@@ -286,7 +286,7 @@ abstract class Gateway
                 $this->configureObjectValueParamForQuery($obj_val, $mix_value);
                 break;
 
-            case 'null':
+            case 'NULL':
                 $obj_val->setStringValue(null);
                 break;
 

--- a/src/GDS/Gateway/RESTv1.php
+++ b/src/GDS/Gateway/RESTv1.php
@@ -398,7 +398,7 @@ class RESTv1 extends \GDS\Gateway
                 $this->configureObjectValueParamForQuery($obj_val, $mix_value);
                 break;
 
-            case 'null':
+            case 'NULL':
                 $obj_val->nullValue = null;
                 break;
 

--- a/tests/GQLParserTest.php
+++ b/tests/GQLParserTest.php
@@ -379,6 +379,31 @@ class GQLParserTest extends \PHPUnit_Framework_TestCase
         $obj_deny_proxy->verify();
     }
 
+    public function testNullParamFallback()
+    {
+        $obj_deny_proxy = new DenyGQLProxyMock();
+        $obj_deny_proxy->init($this);
+
+        $obj_request = new \google\appengine\datastore\v4\RunQueryRequest();
+        $obj_request->setSuggestedBatchSize(1000);
+        $obj_request->mutableReadOptions();
+        $obj_partition = $obj_request->mutablePartitionId();
+        $obj_partition->setDatasetId('Dataset');
+        $obj_query = $obj_request->mutableQuery();
+        $obj_query->addKind()->setName('Book');
+        $obj_prop_filter = $obj_query->mutableFilter()->mutablePropertyFilter()->setOperator(\google\appengine\datastore\v4\PropertyFilter\Operator::EQUAL);
+        $obj_prop_filter->mutableProperty()->setName('author');
+        $obj_prop_filter->mutableValue()->setStringValue(null);
+
+        $obj_deny_proxy->expectCall('datastore_v4', 'RunQuery', $obj_request, new \google\appengine\datastore\v4\RunQueryResponse());
+
+        $obj_gateway = new GDS\Gateway\ProtoBuf('Dataset');
+        $obj_store = new GDS\Store('Book', $obj_gateway);
+        $obj_store->fetchAll("SELECT * FROM Book WHERE author = @author", ['author' => null]);
+
+        $obj_deny_proxy->verify();
+    }
+
     public function testStringifyParamFallback()
     {
         $obj_deny_proxy = new DenyGQLProxyMock();

--- a/tests/GQLParserTest.php
+++ b/tests/GQLParserTest.php
@@ -360,7 +360,6 @@ class GQLParserTest extends \PHPUnit_Framework_TestCase
 
         $obj_request = new \google\appengine\datastore\v4\RunQueryRequest();
         $obj_request->setSuggestedBatchSize(1000);
-        $obj_request->setSuggestedBatchSize(1000);
         $obj_request->mutableReadOptions();
         $obj_partition = $obj_request->mutablePartitionId();
         $obj_partition->setDatasetId('Dataset');

--- a/tests/RESTv1GatewayTest.php
+++ b/tests/RESTv1GatewayTest.php
@@ -742,7 +742,7 @@ class RESTv1GatewayTest extends \RESTv1Test
         $obj_http = $this->initTestHttpClient('https://datastore.googleapis.com/v1/projects/DatasetTest:runQuery', ['json' => (object)[
             'gqlQuery' => (object)[
                 'allowLiterals' => true,
-                'queryString' => 'SELECT * FROM Test WHERE booly = @booly AND stringy = @stringy AND inty = @inty AND floaty = @floaty AND datey = @datey AND somekey = @somekey LIMIT 1',
+                'queryString' => 'SELECT * FROM Test WHERE booly = @booly AND stringy = @stringy AND inty = @inty AND floaty = @floaty AND datey = @datey AND somekey = @somekey AND nully = @nully LIMIT 1',
                 'namedBindings' => (object)[
                     'booly' => (object)[
                         'value' => (object)[
@@ -784,6 +784,11 @@ class RESTv1GatewayTest extends \RESTv1Test
                             ]
                         ]
                     ],
+                    'nully' => (object)[
+                        'value' => (object)[
+                            'nullValue' => null
+                        ]
+                    ],
                 ]
             ],
             'partitionId' => (object)[
@@ -802,13 +807,14 @@ class RESTv1GatewayTest extends \RESTv1Test
         $obj_store = new \GDS\Store('Test', $obj_gateway);
 
         $obj_key_entity = $obj_store->createEntity()->setKeyName('my-first-key-name');
-        $obj_store->fetchOne("SELECT * FROM Test WHERE booly = @booly AND stringy = @stringy AND inty = @inty AND floaty = @floaty AND datey = @datey AND somekey = @somekey", [
+        $obj_store->fetchOne("SELECT * FROM Test WHERE booly = @booly AND stringy = @stringy AND inty = @inty AND floaty = @floaty AND datey = @datey AND somekey = @somekey AND nully = @nully", [
             'booly' => true,
             'stringy' => 'test',
             'inty' => 123,
             'floaty' => 4.56,
             'datey' => new DateTime('1955-11-10 01:02:03'),
-            'somekey' => $obj_key_entity
+            'somekey' => $obj_key_entity,
+            'nully' => null,
         ]);
 
         $this->validateHttpClient($obj_http);


### PR DESCRIPTION
Fixed support for null. Also, expanded tests to verify fix.

Source:
`gettype(null)` returns `NULL` instead of `null` - http://php.net/manual/en/function.gettype.php#refsect1-function.gettype-returnvalues