### PR TITLE
Stopped error when excluding string arrays from indexes

### DIFF
--- a/src/GDS/Mapper/RESTv1.php
+++ b/src/GDS/Mapper/RESTv1.php
@@ -376,7 +376,10 @@ class RESTv1 extends \GDS\Mapper
         if(isset($arr_field_def['index']) && FALSE === $arr_field_def['index']) {
             $bol_index = FALSE;
         }
-        $obj_property_value->excludeFromIndexes = !$bol_index;
+        // Docs: "A Value instance that sets field arrayValue must not set fields meaning or excludeFromIndexes."
+        if($arr_field_def['type'] !== Schema::PROPERTY_STRING_LIST) {
+           $obj_property_value->excludeFromIndexes = !$bol_index;
+        }
 
         switch ($arr_field_def['type']) {
             case Schema::PROPERTY_STRING:
@@ -424,7 +427,7 @@ class RESTv1 extends \GDS\Mapper
                 break;
 
             case Schema::PROPERTY_STRING_LIST:
-                // Docs: "A Value instance that sets field arrayValue must not set fields meaning or excludeFromIndexes."
+                // As we cannot set excludeFromIndexes on the property itself, set it on each value in the array
                 $arr_values = [];
                 foreach ((array)$mix_value as $str) {
                     $obj_value = (object)['stringValue' => $str];


### PR DESCRIPTION
excludeFromIndexes was being set on both the string list property _and_ each value in the string list. If only set on the values then no error occurs and the string list is un-indexed in GDS as expected