### PR TITLE
Datastore emulator support

### DIFF
--- a/src/GDS/Gateway/RESTv1.php
+++ b/src/GDS/Gateway/RESTv1.php
@@ -90,10 +90,11 @@ class RESTv1 extends \GDS\Gateway
 
         // Middleware
         $obj_stack = HandlerStack::create();
-        $obj_stack->push(ApplicationDefaultCredentials::getMiddleware(['https://www.googleapis.com/auth/datastore']));
 
         if (getenv("DATASTORE_EMULATOR_HOST") !== FALSE) {
             $this->base_url = getenv("DATASTORE_EMULATOR_HOST");
+        } else {
+            $obj_stack->push(ApplicationDefaultCredentials::getMiddleware(['https://www.googleapis.com/auth/datastore']));
         }
 
         // Create the HTTP client

--- a/src/GDS/Store.php
+++ b/src/GDS/Store.php
@@ -78,8 +78,16 @@ class Store
     public function __construct($kind_schema = null, Gateway $obj_gateway = null)
     {
         $this->obj_schema = $this->determineSchema($kind_schema);
-        $this->obj_gateway = (null === $obj_gateway) ? new \GDS\Gateway\ProtoBuf() : $obj_gateway;
         $this->str_last_query = 'SELECT * FROM `' . $this->obj_schema->getKind() . '` ORDER BY __key__ ASC';
+
+        if (null !== $obj_gateway) {
+            $this->obj_gateway = $obj_gateway;
+        } elseif (getenv("DATASTORE_EMULATOR_HOST") !== FALSE) {
+            $application_id = isset($_SERVER['APPLICATION_ID']) ? $_SERVER['APPLICATION_ID'] : 'local-app-id';
+            $this->obj_gateway = new \GDS\Gateway\RESTv1($application_id);
+        } else {
+            $this->obj_gateway = new \GDS\Gateway\ProtoBuf();
+        }
     }
 
     /**


### PR DESCRIPTION
When using datastore emulator (`DATASTORE_EMULATOR_HOST ` is set):
- There's no need to obtain credentials from Google api.
- If no gateway provided, use RESTv1 gateway which supports datastore emulator.

This PR should make most local unit testing works by default, without changing application code.