### PR TITLE
refactored base_url action method

### DIFF
--- a/src/GDS/Mapper/RESTv1.php
+++ b/src/GDS/Mapper/RESTv1.php
@@ -99,6 +99,11 @@ class RESTv1 extends \GDS\Mapper
     protected function extractStringListValue($obj_property)
     {
         $arr_values = [];
+
+        if (!isset($obj_property->arrayValue->values)) {
+            return $arr_values;
+        }
+
         foreach((array)$obj_property->arrayValue->values as $obj_value) {
             if(isset($obj_value->stringValue)) {
                 $arr_values[] = $obj_value->stringValue;


### PR DESCRIPTION
The `$base_url` is referenced directly within the `actionUrl`. So even if you provide your own client and set a different `base_url` it will not be applied on the `actionUrl`.

This PR sets to change that behaviour by getting the `base_url` from the client or return the default. 