### PR TITLE
Feature - Support microseconds in DateTime properties

### DIFF
--- a/src/GDS/Mapper/ProtoBuf.php
+++ b/src/GDS/Mapper/ProtoBuf.php
@@ -254,7 +254,7 @@ class ProtoBuf extends \GDS\Mapper
         // Attempt to retain microsecond precision
         return \DateTime::createFromFormat(
             self::DATETIME_FORMAT_UDOTU,
-            sprintf('%0.6F', bcdiv($obj_property->getTimestampMicrosecondsValue(), self::MICROSECONDS))
+            sprintf('%0.6F', bcdiv($obj_property->getTimestampMicrosecondsValue(), self::MICROSECONDS, 6))
         );
 
         // Works, to seconds only


### PR DESCRIPTION
bcdiv without the third parameter (unless the caller set bcscale), discards all decimal number (https://www.php.net/manual/en/function.bcdiv.php).

This means that if 2 entries are created in the same seconds, they can potentially be shuffled.