### PR TITLE
fix: use GAE_APPLICATION env var in ProtoBuf gateway

### DIFF
--- a/src/GDS/Gateway/ProtoBuf.php
+++ b/src/GDS/Gateway/ProtoBuf.php
@@ -67,7 +67,9 @@ class ProtoBuf extends \GDS\Gateway
         if(null === $str_dataset) {
             if(isset($_SERVER['APPLICATION_ID'])) {
                 $this->str_dataset_id = $_SERVER['APPLICATION_ID'];
-            } else {
+            } elseif (isset($_SERVER['GAE_APPLICATION'])) {
+                $this->str_dataset_id = $_SERVER['GAE_APPLICATION'];
+            }  else {
                 throw new \Exception('Could not determine DATASET, please pass to ' . get_class($this) . '::__construct()');
             }
         } else {


### PR DESCRIPTION
In App Engine PHP 7 runtimes, GAE_APPLICATION is the Google Cloud project ID [0] and the APPLICATION_ID env var is no longer set.

[0] https://cloud.google.com/appengine/docs/standard/php7/runtime#special_server_keys