### PR TITLE
Support for exponential back-off.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This library is intended to make it easier for you to get started with and to us
 
 ## Quick Start ##
 ```bash
-composer require "tomwalder/php-gds:^5.1"
+composer require "tomwalder/php-gds:^6.1"
 ```
 ```php
 // Build a new entity
@@ -27,6 +27,18 @@ foreach($obj_store->fetchAll() as $obj_book) {
     echo "Title: {$obj_book->title}, ISBN: {$obj_book->isbn} <br />", PHP_EOL;
 }
 ```
+
+## New in Version 6.1 ##
+
+Support for automated exponential backoff for some types of errors. See documentation here: 
+https://cloud.google.com/datastore/docs/concepts/errors
+
+To enable:
+```php
+\GDS\Gateway::exponentialBackoff(true);
+```
+
+Version `6.0.0` introduced better (but different) support for `NULL` values.
 
 ## New in Version 5.0 ##
 

--- a/README.md
+++ b/README.md
@@ -535,6 +535,10 @@ A full suite of unit tests is in the works. Assuming you've installed `php-gds` 
 ```bash
 vendor/bin/phpunit
 ```
+Or, if you need to run containerised tests, you can use the `runphp` image (or any you choose)
+```bash
+docker run --rm -it -v`pwd`:/app -w /app fluentthinking/runphp:7.4.33-v0.9.0 php /app/vendor/bin/phpunit
+```
 
 [Click here for more details](tests/).
 

--- a/src/GDS/Gateway/RESTv1.php
+++ b/src/GDS/Gateway/RESTv1.php
@@ -505,7 +505,7 @@ class RESTv1 extends \GDS\Gateway
      * @return string
      */
     protected function getBaseUrl() {
-        $str_base_url = $this->obj_http_client->getConfig(self::CONFIG_CLIENT_BASE_URL);
+        $str_base_url = $this->httpClient()->getConfig(self::CONFIG_CLIENT_BASE_URL);
         if (!empty($str_base_url)) {
             return $str_base_url;
         }

--- a/src/GDS/Gateway/RESTv1.php
+++ b/src/GDS/Gateway/RESTv1.php
@@ -172,41 +172,14 @@ class RESTv1 extends \GDS\Gateway
         if(null !== $obj_request_body) {
             $arr_options['json'] = $obj_request_body;
         }
-        $obj_response = $this->retryablePostRequest($this->actionUrl($str_action), $arr_options);
-        $this->obj_last_response = \json_decode((string)$obj_response->getBody());
-    }
-
-    /**
-     * Attempt an HTTP POST, with retry if enabled
-     *
-     * @param string $str_url
-     * @param array $arr_options
-     * @return ResponseInterface
-     */
-    private function retryablePostRequest(string $str_url, array $arr_options = []): ResponseInterface
-    {
-        $int_attempt = 0;
-        do {
-            try {
-                $int_attempt++;
-                if ($int_attempt > 1) {
-                    $this->backoff($int_attempt);
-                }
+        $str_url = $this->actionUrl($str_action);
+        $obj_response = $this->executeWithExponentialBackoff(
+            function () use ($str_url, $arr_options) {
                 return $this->httpClient()->post($str_url, $arr_options);
-            } catch (\GuzzleHttp\Exception\RequestException $obj_thrown) {
-                if (false === self::$bol_retry || !in_array((int) $obj_thrown->getCode(), self::RETRY_ERROR_CODES)) {
-                    // Rethrow non-retryable errors or if retry is disabled
-                    throw $obj_thrown;
-                }
-                if (in_array((int) $obj_thrown->getCode(), self::RETRY_ONCE_CODES)) {
-                    // Just one retry for some errors
-                    $int_attempt = self::RETRY_MAX_ATTEMPTS - 1;
-                }
-            }
-        } while ($int_attempt < self::RETRY_MAX_ATTEMPTS);
-
-        // We could not make this work after max retries
-        throw $obj_thrown;
+            },
+            \GuzzleHttp\Exception\RequestException::class
+        );
+        $this->obj_last_response = \json_decode((string)$obj_response->getBody());
     }
 
     /**

--- a/tests/BackoffTest.php
+++ b/tests/BackoffTest.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Copyright 2023 Tom Walder
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for exponential backoff
+ *
+ * @author Tom Walder <twalder@gmail.com>
+ */
+class BackoffTest extends \PHPUnit\Framework\TestCase
+{
+    public function testOnceAndReturn()
+    {
+        \GDS\Gateway::exponentialBackoff(true);
+        $shouldBeCalled = $this->getMockBuilder(\stdClass::class)
+            ->addMethods(['__invoke'])
+            ->getMock();
+        $shouldBeCalled->expects($this->once())
+            ->method('__invoke')
+            ->willReturn(87);
+        $int_result = $this->buildTestGateway()->runExecuteWithExponentialBackoff($shouldBeCalled);
+        $this->assertEquals(87, $int_result);
+    }
+
+    public function testBackoffCount()
+    {
+        \GDS\Gateway::exponentialBackoff(true);
+        $shouldBeCalled = $this->getMockBuilder(\stdClass::class)
+            ->addMethods(['__invoke'])
+            ->getMock();
+        $shouldBeCalled->expects($this->exactly(\GDS\Gateway::RETRY_MAX_ATTEMPTS))
+            ->method('__invoke')
+            ->willThrowException(new \RuntimeException('Test Exception', 503));
+        $this->expectException(\RuntimeException::class);
+        $this->buildTestGateway()->runExecuteWithExponentialBackoff($shouldBeCalled);
+    }
+
+    public function testBackoffCountDisabled()
+    {
+        \GDS\Gateway::exponentialBackoff(false);
+        $shouldBeCalled = $this->getMockBuilder(\stdClass::class)
+            ->addMethods(['__invoke'])
+            ->getMock();
+        $shouldBeCalled->expects($this->once())
+            ->method('__invoke')
+            ->willThrowException(new \RuntimeException('Not retried', 503));
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Not retried');
+        $this->expectExceptionCode(503);
+        $this->buildTestGateway()->runExecuteWithExponentialBackoff($shouldBeCalled);
+    }
+
+    public function testPartialBackoff() {
+        \GDS\Gateway::exponentialBackoff(true);
+        $int_calls = 0;
+        $shouldBeCalled = function () use (&$int_calls) {
+            $int_calls++;
+            if ($int_calls < 4) {
+                throw new \RuntimeException('Always caught', 503);
+            }
+            return 42;
+        };
+        $int_result = $this->buildTestGateway()->runExecuteWithExponentialBackoff($shouldBeCalled);
+        $this->assertEquals(42, $int_result);
+        $this->assertEquals(4, $int_calls);
+    }
+
+
+    public function testIgnoredExceptionClass()
+    {
+        \GDS\Gateway::exponentialBackoff(true);
+        $shouldBeCalled = $this->getMockBuilder(\stdClass::class)
+            ->addMethods(['__invoke'])
+            ->getMock();
+        $shouldBeCalled->expects($this->once())
+            ->method('__invoke')
+            ->willThrowException(new \LogicException('Ignored', 503));
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Ignored');
+        $this->expectExceptionCode(503);
+        $this->buildTestGateway()->runExecuteWithExponentialBackoff(
+            $shouldBeCalled,
+            \RuntimeException::class
+        );
+    }
+
+    public function testIgnoredExceptionCode()
+    {
+        \GDS\Gateway::exponentialBackoff(true);
+        $shouldBeCalled = $this->getMockBuilder(\stdClass::class)
+            ->addMethods(['__invoke'])
+            ->getMock();
+        $shouldBeCalled->expects($this->once())
+            ->method('__invoke')
+            ->willThrowException(new \RuntimeException('Non-retry code', 42));
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Non-retry code');
+        $this->expectExceptionCode(42);
+        $this->buildTestGateway()->runExecuteWithExponentialBackoff($shouldBeCalled);
+    }
+
+    public function testRetryOnce()
+    {
+        \GDS\Gateway::exponentialBackoff(true);
+        $int_calls = 0;
+        $shouldBeCalled = function () use (&$int_calls) {
+            $int_calls++;
+            throw new \RuntimeException('Once', 500);
+        };
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Once');
+        $this->expectExceptionCode(500);
+        $this->buildTestGateway()->runExecuteWithExponentialBackoff($shouldBeCalled);
+        $this->assertEquals(2, $int_calls);
+    }
+
+    private function buildTestGateway(): \RESTv1GatewayBackoff
+    {
+        return new RESTv1GatewayBackoff('dataset-id', 'my-app');
+    }
+}

--- a/tests/base/RESTv1GatewayBackoff.php
+++ b/tests/base/RESTv1GatewayBackoff.php
@@ -1,0 +1,13 @@
+<?php
+
+class RESTv1GatewayBackoff extends \GDS\Gateway\RESTv1
+{
+
+    public function runExecuteWithExponentialBackoff(
+        callable $fnc_main,
+        string $str_exception = null,
+        callable $fnc_resolve_exception = null
+    ) {
+        return $this->executeWithExponentialBackoff($fnc_main, $str_exception, $fnc_resolve_exception);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,6 +12,7 @@ date_default_timezone_set('UTC');
 require_once(dirname(__FILE__) . '/../vendor/autoload.php');
 
 // Base Test Files
+require_once(dirname(__FILE__) . '/base/RESTv1GatewayBackoff.php');
 require_once(dirname(__FILE__) . '/base/RESTv1Test.php');
 require_once(dirname(__FILE__) . '/base/Simple.php');
 require_once(dirname(__FILE__) . '/base/Book.php');


### PR DESCRIPTION
## New in Version 6.1 ##

Support for automated exponential backoff for some types of errors. See documentation here: 
https://cloud.google.com/datastore/docs/concepts/errors

To enable:
```php
\GDS\Gateway::exponentialBackoff(true);
```

Version `6.0.0` introduced better (but different) support for `NULL` values.
